### PR TITLE
Attempt to fix issue date bug

### DIFF
--- a/apps/app/src/lib/components/Invoice.svelte
+++ b/apps/app/src/lib/components/Invoice.svelte
@@ -16,6 +16,8 @@
 	export let styles: InvoiceStyles;
 	export let data: FullInvoice;
 
+	let stringIssueDate: string = data.issueDate.toLocaleDateString('en-ZA').replaceAll('/', '-');
+
 	$: {
 		data.subtotal = parseFloat(
 			data.lineItems
@@ -28,6 +30,8 @@
 		data.tax = parseFloat(((data.subtotal * data.taxPercentage) / 100).toFixed(2));
 
 		data.total = parseFloat((data.subtotal + data.tax).toFixed(2));
+
+		data.issueDate = new Date(stringIssueDate);
 	}
 
 	$: console.log(data);
@@ -53,11 +57,7 @@
 		</div>
 		<Spacer divider={'hidden'} spacing={styles.baseSpacing} color={styles.baseDividerColor} />
 		<div class="grid grid-cols-1 leading-6">
-			<IssueDate
-				{editable}
-				align={styles.issueDateAlign}
-				date={data.issueDate.toLocaleDateString('en-ZA').replaceAll('/', '-')}
-			/>
+			<IssueDate {editable} align={styles.issueDateAlign} bind:date={stringIssueDate} />
 			<Spacer
 				divider={styles.baseDivider}
 				spacing={styles.baseSpacing}

--- a/apps/app/src/lib/components/invoice/IssueDate.svelte
+++ b/apps/app/src/lib/components/invoice/IssueDate.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { twMerge } from 'tailwind-merge';
 	export let editable: boolean = false;
-	export let date = new Date().toLocaleDateString('en-ZA').replaceAll('/', '-');
+	export let date: string = new Date().toLocaleDateString('en-ZA').replaceAll('/', '-');
 	export let align = 'text-right';
 </script>
 

--- a/apps/app/src/routes/(app)/invoices/template/design/+page.svelte
+++ b/apps/app/src/routes/(app)/invoices/template/design/+page.svelte
@@ -25,6 +25,7 @@
 	invoice.client.name = 'Client Name';
 	invoice.sendersAddress = displayAddress;
 	invoice.client.address = displayAddress;
+	invoice.issueDate = new Date();
 
 	const { form, message, enhance } = superForm(data.form, {
 		resetForm: false,


### PR DESCRIPTION
This pull request includes changes to the `Invoice.svelte` and related components to improve the handling of the `issueDate` property by using a string format. The most important changes are:

### Changes to `Invoice.svelte`:

* Added a new variable `stringIssueDate` to store the formatted `issueDate` as a string.
* Updated the reactive statement to set `data.issueDate` using the new `stringIssueDate` variable.
* Modified the `IssueDate` component to bind the `date` property to `stringIssueDate`.

### Changes to `IssueDate.svelte`:

* Changed the `date` property type to `string` for consistency with the new format.

### Changes to `+page.svelte`:

* Initialized `invoice.issueDate` with the current date.